### PR TITLE
feat: 풀이 시간 분포 히스토그램 차트 구현

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -12,6 +12,7 @@ import type {
   OAuthLoginResponse,
   AuthMeResponse,
   AuthCodeResponse,
+  SolveTimeDistributionResponse,
 } from "../types/api";
 import type { SolvedPeriod, TierGroup } from "../types/types";
 
@@ -160,6 +161,19 @@ export const problemApi = {
   async getProblemDetail(bojProblemId: number): Promise<ProblemDetailResponse> {
     const response = await api.get<ProblemDetailResponse>(
       `/problems/${bojProblemId}`
+    );
+    return response.data;
+  },
+
+  async getSolveTimeDistribution(
+    bojProblemId: number,
+    solveTimeSeconds: number
+  ): Promise<SolveTimeDistributionResponse> {
+    const response = await api.get<SolveTimeDistributionResponse>(
+      `/problems/${bojProblemId}/solve-time-distribution`,
+      {
+        params: { solveTimeSeconds },
+      }
     );
     return response.data;
   },

--- a/src/components/ProblemDetailPanel/ProblemDetailPanel.styled.ts
+++ b/src/components/ProblemDetailPanel/ProblemDetailPanel.styled.ts
@@ -216,6 +216,12 @@ export const EmptySubtext = styled.p`
   margin: 0;
 `;
 
+// Distribution chart
+export const DistributionSection = styled.div`
+  margin-top: ${({ theme }) => theme.spacing(4)};
+  margin-bottom: ${({ theme }) => theme.spacing(2)};
+`;
+
 // BOJ link
 export const BojLink = styled.a`
   display: flex;

--- a/src/components/RetryListCard/RetryListCard.tsx
+++ b/src/components/RetryListCard/RetryListCard.tsx
@@ -9,7 +9,7 @@ type SortOption = "LATEST" | "TIER" | "SOLVE_TIME";
 
 interface RetryListCardProps {
   memberName: string;
-  onProblemClick?: (bojProblemId: number) => void;
+  onProblemClick?: (bojProblemId: number, solveTimeSeconds: number | null) => void;
 }
 
 export function RetryListCard({ memberName, onProblemClick }: RetryListCardProps) {

--- a/src/components/SolveTimeDistributionChart/SolveTimeDistributionChart.styled.ts
+++ b/src/components/SolveTimeDistributionChart/SolveTimeDistributionChart.styled.ts
@@ -1,0 +1,50 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  padding: ${({ theme }) => theme.spacing(4)};
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  background: ${({ theme }) => theme.colors.bgTertiary};
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${({ theme }) => theme.spacing(3)};
+`;
+
+export const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing(2)};
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.text};
+
+  svg {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;
+
+export const PercentBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  background: ${({ theme }) => theme.colors.primaryLight};
+  color: ${({ theme }) => theme.colors.primary};
+  font-size: 0.8rem;
+  font-weight: 700;
+`;
+
+export const SubInfo = styled.p`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.textMuted};
+  margin: 0 0 ${({ theme }) => theme.spacing(3)} 0;
+`;
+
+export const ChartWrapper = styled.div`
+  width: 100%;
+  height: 180px;
+`;

--- a/src/components/SolveTimeDistributionChart/SolveTimeDistributionChart.tsx
+++ b/src/components/SolveTimeDistributionChart/SolveTimeDistributionChart.tsx
@@ -1,0 +1,171 @@
+import { useMemo, useCallback } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { BarChart3 } from "lucide-react";
+import type { SolveTimeDistributionResponse } from "../../types/api";
+import formatSeconds from "../../utils/formatSeconds";
+import * as Styled from "./SolveTimeDistributionChart.styled";
+
+interface SolveTimeDistributionChartProps {
+  data: SolveTimeDistributionResponse;
+  avatarUrl?: string;
+}
+
+function formatShortTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return m > 0 ? `${h}시간 ${m}분` : `${h}시간`;
+  return `${m}분`;
+}
+
+const AVATAR_SIZE = 22;
+const MUTED_COLOR = "#3D3D3D";
+const PRIMARY_COLOR = "#5B9FED";
+
+export function SolveTimeDistributionChart({
+  data,
+  avatarUrl,
+}: SolveTimeDistributionChartProps) {
+  const { distribution, myPosition, totalSolverCount } = data;
+
+  const chartData = useMemo(
+    () =>
+      distribution.map((bucket) => ({
+        label: formatShortTime(bucket.rangeEnd),
+        count: bucket.count,
+        rangeStart: bucket.rangeStart,
+        rangeEnd: bucket.rangeEnd,
+      })),
+    [distribution]
+  );
+
+  const myBucketIndex = useMemo(() => {
+    return distribution.findIndex(
+      (b) =>
+        myPosition.solveTimeSeconds >= b.rangeStart &&
+        myPosition.solveTimeSeconds < b.rangeEnd
+    );
+  }, [distribution, myPosition]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderBar = useCallback((props: any) => {
+    const { x, y, width, height, index } = props;
+    const isMine = index === myBucketIndex;
+    const fill = isMine ? PRIMARY_COLOR : MUTED_COLOR;
+    const r = 2;
+
+    return (
+      <g>
+        <path
+          d={`M${x},${y + r} Q${x},${y} ${x + r},${y}
+              L${x + width - r},${y} Q${x + width},${y} ${x + width},${y + r}
+              L${x + width},${y + height} L${x},${y + height} Z`}
+          fill={fill}
+        />
+        {isMine && avatarUrl && (
+          <>
+            <defs>
+              <clipPath id="dist-avatar-clip">
+                <circle
+                  cx={x + width / 2}
+                  cy={y - AVATAR_SIZE / 2 - 4}
+                  r={AVATAR_SIZE / 2}
+                />
+              </clipPath>
+            </defs>
+            <circle
+              cx={x + width / 2}
+              cy={y - AVATAR_SIZE / 2 - 4}
+              r={AVATAR_SIZE / 2 + 1.5}
+              fill={PRIMARY_COLOR}
+            />
+            <image
+              href={avatarUrl}
+              x={x + width / 2 - AVATAR_SIZE / 2}
+              y={y - AVATAR_SIZE - 4}
+              width={AVATAR_SIZE}
+              height={AVATAR_SIZE}
+              clipPath="url(#dist-avatar-clip)"
+              preserveAspectRatio="xMidYMid slice"
+            />
+          </>
+        )}
+      </g>
+    );
+  }, [myBucketIndex, avatarUrl]);
+
+  return (
+    <Styled.Container>
+      <Styled.Header>
+        <Styled.TitleRow>
+          <BarChart3 size={16} />
+          풀이 시간 분포
+        </Styled.TitleRow>
+        <Styled.PercentBadge>상위 {myPosition.topPercent.toFixed(1)}%</Styled.PercentBadge>
+      </Styled.Header>
+
+      <Styled.SubInfo>
+        총 {totalSolverCount.toLocaleString()}명 중 내 풀이 시간:{" "}
+        {formatSeconds(myPosition.solveTimeSeconds)}
+      </Styled.SubInfo>
+
+      <Styled.ChartWrapper>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart
+            data={chartData}
+            margin={{ top: AVATAR_SIZE + 8, right: 4, left: -20, bottom: 0 }}
+            barCategoryGap="40%"
+          >
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 10, fill: "#8A8D91" }}
+              tickLine={false}
+              axisLine={false}
+              interval={0}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: "#8A8D91" }}
+              tickLine={false}
+              axisLine={false}
+              allowDecimals={false}
+            />
+            <Tooltip
+              cursor={{ fill: "rgba(255,255,255,0.05)" }}
+              content={({ active, payload }) => {
+                if (!active || !payload?.[0]) return null;
+                const d = payload[0].payload as (typeof chartData)[number];
+                return (
+                  <div style={{
+                    background: "#262626",
+                    border: "1px solid #333333",
+                    borderRadius: "8px",
+                    padding: "8px 12px",
+                    fontSize: "0.8rem",
+                  }}>
+                    <div style={{ color: "#B0B3B8", marginBottom: 4 }}>
+                      {formatShortTime(d.rangeStart)}~{formatShortTime(d.rangeEnd)}
+                    </div>
+                    <div style={{ color: "#E4E6EB" }}>
+                      풀이자: {d.count}명
+                    </div>
+                  </div>
+                );
+              }}
+            />
+            <Bar
+              dataKey="count"
+              maxBarSize={14}
+              shape={renderBar}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </Styled.ChartWrapper>
+    </Styled.Container>
+  );
+}

--- a/src/components/SolvedItem/SolvedItem.tsx
+++ b/src/components/SolvedItem/SolvedItem.tsx
@@ -9,7 +9,7 @@ interface SolvedItemProps {
   solved: RecentSolvedResponse;
   showSolveType?: boolean;
   showDate?: boolean;
-  onProblemClick?: (bojProblemId: number) => void;
+  onProblemClick?: (bojProblemId: number, solveTimeSeconds: number | null) => void;
 }
 
 function formatDate(dateString?: string): string {
@@ -34,7 +34,7 @@ export function SolvedItem({ solved, showSolveType = false, showDate = false, on
 
   const handleClick = () => {
     if (onProblemClick) {
-      onProblemClick(solved.problem.bojProblemId);
+      onProblemClick(solved.problem.bojProblemId, solved.solveTimeSeconds);
     } else {
       const id = solved.problem.bojProblemId;
       navigate(`/problems?q=${id}&select=${id}`);

--- a/src/components/SolvedList/SolvedList.tsx
+++ b/src/components/SolvedList/SolvedList.tsx
@@ -6,7 +6,7 @@ import type { RecentSolvedResponse } from "../../types/api";
 
 type SolvedListProps = {
   solveds: RecentSolvedResponse[];
-  onProblemClick?: (bojProblemId: number) => void;
+  onProblemClick?: (bojProblemId: number, solveTimeSeconds: number | null) => void;
 };
 
 export function SolvedList({ solveds, onProblemClick }: SolvedListProps) {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -20,6 +20,7 @@ export function ProfilePage() {
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState<"recent" | "stats" | "retry">("recent");
   const [selectedBojId, setSelectedBojId] = useState<number | null>(null);
+  const [selectedSolveTimeSeconds, setSelectedSolveTimeSeconds] = useState<number | null>(null);
   const [showBojModal, setShowBojModal] = useState(false);
 
   const isMyProfile = user?.name === username;
@@ -46,13 +47,15 @@ export function ProfilePage() {
   const totalTimeSeconds = profile?.totalSolvedTime || 0;
   const averageTimeSeconds = profile?.totalSolvedAverageTime || 0;
 
-  const handleProblemClick = (bojProblemId: number) => {
+  const handleProblemClick = (bojProblemId: number, solveTimeSeconds: number | null) => {
     trackEvent('view_problem_detail', { problem_id: bojProblemId, source: 'profile' });
     setSelectedBojId(bojProblemId);
+    setSelectedSolveTimeSeconds(solveTimeSeconds);
   };
 
   const handleCloseDrawer = () => {
     setSelectedBojId(null);
+    setSelectedSolveTimeSeconds(null);
   };
 
   if (loading) {
@@ -205,7 +208,7 @@ export function ProfilePage() {
           {isDetailLoading ? (
             <Styled.DrawerLoading>불러오는 중...</Styled.DrawerLoading>
           ) : detail ? (
-            <ProblemDetailPanel detail={detail} />
+            <ProblemDetailPanel detail={detail} solveTimeSeconds={selectedSolveTimeSeconds} avatarUrl={profile?.avatarUrl} />
           ) : null}
         </Styled.DrawerBody>
       </Styled.DrawerPanel>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -133,3 +133,25 @@ export interface AuthCodeResponse {
 export interface BojVerifyRequest {
   shareUrl: string;
 }
+
+// 풀이 시간 분포 관련 타입
+export interface DistributionBucket {
+  rangeStart: number;
+  rangeEnd: number;
+  count: number;
+}
+
+export interface MyPosition {
+  solveTimeSeconds: number;
+  topPercent: number;
+}
+
+export interface SolveTimeDistributionResponse {
+  bojProblemId: number;
+  title: string;
+  tier: Tier;
+  totalSolverCount: number;
+  bucketSize: number;
+  distribution: DistributionBucket[];
+  myPosition: MyPosition;
+}


### PR DESCRIPTION
## Summary

프로필 페이지에서 풀이 기록 클릭 시 해당 문제의 전체 풀이 시간 분포를 히스토그램으로 시각화하는 기능을 구현합니다.

### 왜 필요한가?
백엔드에서 풀이 시간 분포 API(`GET /api/problems/{bojProblemId}/solve-time-distribution`)가 구현되었지만, 프론트엔드에서 이를 시각적으로 보여주는 UI가 없었습니다. 히스토그램 차트를 통해 사용자가 자신의 풀이 시간이 전체 분포에서 어느 위치(상위 X%)인지 직관적으로 확인할 수 있도록 합니다.

### 동작 방식
1. 프로필 페이지에서 최근 풀이 기록 또는 다시 도전하기 문제를 클릭합니다.
2. 해당 문제에 `solveTimeSeconds`가 존재하면 분포 API를 호출합니다.
3. Recharts BarChart로 히스토그램을 렌더링하고, 사용자가 속한 버킷을 하이라이트하며 프로필 사진을 막대 위에 표시합니다.

## 주요 변경 사항

- **SolveTimeDistributionChart**: Recharts BarChart 기반 히스토그램 차트 컴포넌트 신규 생성
- **ProblemDetailPanel**: `solveTimeSeconds`, `avatarUrl` prop 추가, 분포 API 호출 및 차트 렌더링, 풀이 기록에서 열 때 Recommendation 섹션 숨김
- **onProblemClick 시그니처 변경**: `SolvedItem`, `SolvedList`, `RetryListCard`에서 `solveTimeSeconds`를 함께 전달
- **ProfilePage**: `selectedSolveTimeSeconds` state 추가, `ProblemDetailPanel`에 `solveTimeSeconds`와 `avatarUrl` 전달
- **타입 및 API**: `SolveTimeDistributionResponse` 타입, `problemApi.getSolveTimeDistribution` 함수 추가