### PR TITLE
fix: 분포 차트 마지막 버킷 매칭 및 X축 라벨 겹침 수정

### DIFF
--- a/src/components/SolveTimeDistributionChart/SolveTimeDistributionChart.tsx
+++ b/src/components/SolveTimeDistributionChart/SolveTimeDistributionChart.tsx
@@ -46,10 +46,13 @@ export function SolveTimeDistributionChart({
   );
 
   const myBucketIndex = useMemo(() => {
+    const lastIdx = distribution.length - 1;
     return distribution.findIndex(
-      (b) =>
+      (b, i) =>
         myPosition.solveTimeSeconds >= b.rangeStart &&
-        myPosition.solveTimeSeconds < b.rangeEnd
+        (i === lastIdx
+          ? myPosition.solveTimeSeconds <= b.rangeEnd
+          : myPosition.solveTimeSeconds < b.rangeEnd)
     );
   }, [distribution, myPosition]);
 
@@ -127,7 +130,7 @@ export function SolveTimeDistributionChart({
               tick={{ fontSize: 10, fill: "#8A8D91" }}
               tickLine={false}
               axisLine={false}
-              interval={0}
+              interval={chartData.length > 12 ? 2 : chartData.length > 7 ? 1 : 0}
             />
             <YAxis
               tick={{ fontSize: 10, fill: "#8A8D91" }}


### PR DESCRIPTION
## Summary

#4에서 구현한 풀이 시간 분포 차트의 두 가지 버그를 수정합니다.

### 주요 변경 사항
- **마지막 버킷 매칭 수정**: 풀이 시간이 마지막 버킷의 `rangeEnd`와 정확히 같을 때(예: 40분 풀이, 마지막 버킷 35분~40분) 프로필 사진이 표시되지 않던 버그 수정 (`<` → `<=` 경계 처리)
- **X축 라벨 겹침 수정**: 버킷 수가 많을 때(최대 20개) X축 라벨이 겹쳐 보이는 문제를 interval 동적 조정으로 해결