### PR TITLE
feat: XP/레벨 기능 안내 모달 추가

### DIFF
--- a/src/components/XpGuideModal/XpGuideModal.styled.ts
+++ b/src/components/XpGuideModal/XpGuideModal.styled.ts
@@ -1,0 +1,246 @@
+import styled, { keyframes } from "styled-components";
+
+const fadeIn = keyframes`
+  from { opacity: 0; }
+  to { opacity: 1; }
+`;
+
+const slideUp = keyframes`
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+`;
+
+export const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => theme.spacing(4)};
+  animation: ${fadeIn} 0.15s ease;
+`;
+
+export const Modal = styled.div`
+  background: ${({ theme }) => theme.colors.bgSecondary};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: ${({ theme }) => theme.shadows.md};
+  animation: ${slideUp} 0.2s ease;
+`;
+
+export const ModalHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing(5)} ${({ theme }) => theme.spacing(6)};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+`;
+
+export const ModalTitle = styled.h2`
+  font-size: 1rem;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.text};
+  margin: 0;
+`;
+
+export const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: none;
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  color: ${({ theme }) => theme.colors.textSecondary};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.bgTertiary};
+    color: ${({ theme }) => theme.colors.text};
+  }
+`;
+
+export const ModalBody = styled.div`
+  padding: ${({ theme }) => theme.spacing(6)};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(5)};
+`;
+
+export const Intro = styled.p`
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  margin: 0;
+  line-height: 1.7;
+`;
+
+export const StepList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(3)};
+`;
+
+export const StepItem = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(3)};
+  padding: ${({ theme }) => theme.spacing(4)};
+  background: ${({ theme }) => theme.colors.bg};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+`;
+
+export const StepIcon = styled.div`
+  font-size: 1.25rem;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 1px;
+`;
+
+export const StepContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(1)};
+`;
+
+export const StepTitle = styled.p`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.text};
+  margin: 0;
+`;
+
+export const StepDesc = styled.p`
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  margin: 0;
+  line-height: 1.6;
+`;
+
+export const Divider = styled.hr`
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.colors.border};
+  margin: 0;
+`;
+
+export const SectionTitle = styled.p`
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+`;
+
+export const Table = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(2)};
+`;
+
+export const TableRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing(2.5)} ${({ theme }) => theme.spacing(3)};
+  background: ${({ theme }) => theme.colors.bg};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+`;
+
+export const TableLabel = styled.span`
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+`;
+
+export const TableValue = styled.span`
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+export const LevelList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(2)};
+`;
+
+export const LevelRow = styled.div<{ $background: string; $textColor: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${({ theme }) => theme.spacing(2.5)} ${({ theme }) => theme.spacing(3)};
+  background: ${({ theme }) => theme.colors.bg};
+  border: 1px solid ${({ theme }) => theme.colors.border};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+`;
+
+export const LevelBadge = styled.span<{ $background: string; $textColor: string; $glow?: string }>`
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: ${({ $textColor }) => $textColor};
+  background: ${({ $background }) => $background};
+  padding: 2px 10px;
+  border-radius: 999px;
+  ${({ $glow }) => $glow && `box-shadow: ${$glow};`}
+`;
+
+export const LevelRange = styled.span`
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+export const TipBox = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(3)};
+  padding: ${({ theme }) => theme.spacing(4)};
+  background: rgba(91, 159, 237, 0.08);
+  border: 1px solid rgba(91, 159, 237, 0.25);
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+`;
+
+export const TipIcon = styled.span`
+  font-size: 1rem;
+  flex-shrink: 0;
+`;
+
+export const TipText = styled.p`
+  font-size: 0.8rem;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  margin: 0;
+  line-height: 1.6;
+
+  strong {
+    color: ${({ theme }) => theme.colors.primary};
+    font-weight: 600;
+  }
+`;
+
+export const ConfirmButton = styled.button`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing(3)};
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: white;
+  background: ${({ theme }) => theme.colors.primary};
+  border: none;
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.primaryHover};
+  }
+
+  &:active {
+    transform: scale(0.99);
+  }
+`;

--- a/src/components/XpGuideModal/XpGuideModal.tsx
+++ b/src/components/XpGuideModal/XpGuideModal.tsx
@@ -1,0 +1,123 @@
+import { X } from "lucide-react";
+import { getLevelStyle } from "../../constants/levelColors";
+import * as S from "./XpGuideModal.styled";
+
+interface XpGuideModalProps {
+  onClose: () => void;
+}
+
+const LEVEL_TIERS = [
+  { label: "코딩 새싹", range: "Lv 1 ~ 10", level: 5 },
+  { label: "알고리즘 탐험가", range: "Lv 11 ~ 30", level: 20 },
+  { label: "문제 해결사", range: "Lv 31 ~ 60", level: 45 },
+  { label: "알고리즘 장인", range: "Lv 61 ~ 90", level: 75 },
+  { label: "전설", range: "Lv 91 ~ 100", level: 95 },
+  { label: "전설 ★", range: "Lv 100", level: 100 },
+];
+
+export function XpGuideModal({ onClose }: XpGuideModalProps) {
+  return (
+    <S.Backdrop onClick={onClose}>
+      <S.Modal onClick={(e) => e.stopPropagation()}>
+        <S.ModalHeader>
+          <S.ModalTitle>경험치 & 레벨 안내</S.ModalTitle>
+          <S.CloseButton onClick={onClose}>
+            <X size={16} />
+          </S.CloseButton>
+        </S.ModalHeader>
+
+        <S.ModalBody>
+          <S.Intro>
+            문제를 풀면 경험치(XP)가 쌓여요. 오래 고민할수록, 어려운 문제일수록,
+            스스로 풀수록 더 많은 XP를 받아요.
+          </S.Intro>
+
+          <S.StepList>
+            <S.StepItem>
+              <S.StepIcon>🧠</S.StepIcon>
+              <S.StepContent>
+                <S.StepTitle>스스로 풀기</S.StepTitle>
+                <S.StepDesc>
+                  풀이 시간 × 티어 가중치 × 1.5 XP를 획득해요.
+                  오래 고민한 만큼 더 많이 받아요 (최대 240분까지 적용).
+                </S.StepDesc>
+              </S.StepContent>
+            </S.StepItem>
+
+            <S.StepItem>
+              <S.StepIcon>📖</S.StepIcon>
+              <S.StepContent>
+                <S.StepTitle>답지 참고</S.StepTitle>
+                <S.StepDesc>
+                  티어 가중치 × 15 XP를 고정으로 획득해요.
+                  풀이 시간과 무관하게 일정한 XP가 지급돼요.
+                </S.StepDesc>
+              </S.StepContent>
+            </S.StepItem>
+
+            <S.StepItem>
+              <S.StepIcon>🔁</S.StepIcon>
+              <S.StepContent>
+                <S.StepTitle>복습 풀이</S.StepTitle>
+                <S.StepDesc>
+                  복습 스케줄에 등록된 문제를 다시 풀면 보너스가 붙어요.<br />
+                  스스로 풀었다면: 풀이 시간 × 티어 가중치 × 2.0 XP<br />
+                  답지를 참고했다면: 티어 가중치 × 18 XP
+                </S.StepDesc>
+              </S.StepContent>
+            </S.StepItem>
+          </S.StepList>
+
+          <S.Divider />
+
+          <S.SectionTitle>스트릭 보너스</S.SectionTitle>
+          <S.Table>
+            <S.TableRow>
+              <S.TableLabel>7일 연속</S.TableLabel>
+              <S.TableValue>× 1.10</S.TableValue>
+            </S.TableRow>
+            <S.TableRow>
+              <S.TableLabel>14일 연속</S.TableLabel>
+              <S.TableValue>× 1.20</S.TableValue>
+            </S.TableRow>
+            <S.TableRow>
+              <S.TableLabel>30일 연속</S.TableLabel>
+              <S.TableValue>× 1.30 (최대)</S.TableValue>
+            </S.TableRow>
+          </S.Table>
+
+          <S.Divider />
+
+          <S.SectionTitle>레벨 & 칭호</S.SectionTitle>
+          <S.LevelList>
+            {LEVEL_TIERS.map(({ label, range, level }) => {
+              const style = getLevelStyle(level);
+              return (
+                <S.LevelRow key={label} $background={style.background} $textColor={style.textColor}>
+                  <S.LevelBadge
+                    $background={style.background}
+                    $textColor={style.textColor}
+                    $glow={style.glow}
+                  >
+                    {label}
+                  </S.LevelBadge>
+                  <S.LevelRange>{range}</S.LevelRange>
+                </S.LevelRow>
+              );
+            })}
+          </S.LevelList>
+
+          <S.TipBox>
+            <S.TipIcon>💡</S.TipIcon>
+            <S.TipText>
+              <strong>Unrated</strong> 문제는 XP가 지급되지 않아요.
+              어려운 문제에 오래 도전하는 습관이 빠른 성장으로 이어져요!
+            </S.TipText>
+          </S.TipBox>
+
+          <S.ConfirmButton onClick={onClose}>확인</S.ConfirmButton>
+        </S.ModalBody>
+      </S.Modal>
+    </S.Backdrop>
+  );
+}

--- a/src/pages/ProfilePage.styled.ts
+++ b/src/pages/ProfilePage.styled.ts
@@ -204,11 +204,35 @@ export const InlineXpFill = styled.div<{ $percent: number; $bar: string }>`
   transition: width 0.5s ease;
 `;
 
+export const InlineXpRightGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing(2)};
+`;
+
 export const InlineXpTotal = styled.span`
   font-size: 0.78rem;
   font-weight: 600;
   color: ${({ theme }) => theme.colors.textSecondary};
   white-space: nowrap;
+`;
+
+export const XpGuideButton = styled.button`
+  font-size: 0.68rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.textMuted};
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color 0.15s ease;
+  white-space: nowrap;
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.textSecondary};
+  }
 `;
 
 export const InlineXpProgressLabel = styled.div`

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -8,6 +8,7 @@ import { ReviewSection } from "../components/ReviewSection/ReviewSection";
 import { TierStatsChart } from "../components/TierStatsChart/TierStatsChart";
 import { ProblemDetailPanel } from "../components/ProblemDetailPanel/ProblemDetailPanel";
 import { BojLinkModal } from "../components/BojLinkModal/BojLinkModal";
+import { XpGuideModal } from "../components/XpGuideModal/XpGuideModal";
 import { ActivityHeatmap } from "../components/ActivityHeatmap/ActivityHeatmap";
 import { WeekSummaryCard } from "../components/WeekSummaryCard/WeekSummaryCard";
 import { ProfileStatsCard } from "../components/ProfileStatsCard/ProfileStatsCard";
@@ -29,6 +30,7 @@ export function ProfilePage() {
   const [selectedBojId, setSelectedBojId] = useState<number | null>(null);
   const [selectedSolveTimeSeconds, setSelectedSolveTimeSeconds] = useState<number | null>(null);
   const [showBojModal, setShowBojModal] = useState(false);
+  const [showXpGuide, setShowXpGuide] = useState(false);
 
   const isMyProfile = user?.name === username;
   const needsBojLink = isMyProfile && !user?.bojId;
@@ -159,7 +161,10 @@ export function ProfilePage() {
                         <Zap size={12} />
                         {xpSummary.title}
                       </Styled.InlineXpTitle>
-                      <Styled.InlineXpTotal>{xpSummary.totalXp.toLocaleString()} XP</Styled.InlineXpTotal>
+                      <Styled.InlineXpRightGroup>
+                        <Styled.InlineXpTotal>{xpSummary.totalXp.toLocaleString()} XP</Styled.InlineXpTotal>
+                        <Styled.XpGuideButton onClick={() => setShowXpGuide(true)}>이 기능은?</Styled.XpGuideButton>
+                      </Styled.InlineXpRightGroup>
                     </Styled.InlineXpRow>
                     <Styled.InlineXpTrack>
                       <Styled.InlineXpFill $percent={xpSummary.progressPercent} $bar={levelStyle.progressBar} />
@@ -268,6 +273,7 @@ export function ProfilePage() {
       </Styled.DrawerPanel>
 
       {showBojModal && <BojLinkModal onClose={() => setShowBojModal(false)} />}
+      {showXpGuide && <XpGuideModal onClose={() => setShowXpGuide(false)} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- XP/레벨 시스템을 처음 보는 사용자를 위한 안내 모달 추가

## 왜 필요한가
- XP가 어떻게 쌓이는지, 레벨 구간이 어떻게 되는지 UI에서 바로 확인할 수 없었음
- 복습 스케줄러와 동일하게 "이 기능은?" 버튼으로 진입하는 안내 모달 제공

## 동작 방식
- 프로필 페이지 XP 바 우측 '이 기능은?' 버튼 클릭 → 모달 오픈
- 모달 내 구성: 스스로 풀기 / 답지 참고 / 복습 풀이 XP 계산 방식, 스트릭 보너스 표, 레벨별 칭호 목록, 팁

## 주요 변경 사항
- `src/components/XpGuideModal/XpGuideModal.tsx` — 안내 모달 컴포넌트
- `src/components/XpGuideModal/XpGuideModal.styled.ts` — Styled Components
- `src/pages/ProfilePage.tsx` — showXpGuide 상태 + '이 기능은?' 버튼 연결
- `src/pages/ProfilePage.styled.ts` — InlineXpRightGroup, XpGuideButton 추가

## Test plan
- [x] 프로필 페이지 XP 바 우측 '이 기능은?' 클릭 시 모달 열림
- [x] 배경 클릭 또는 확인 버튼으로 모달 닫힘
- [x] 레벨별 칭호 색상이 실제 레벨 색상과 일치