### PR TITLE
feat: 채널톡 위젯 추가 및 회원 정보 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,10 @@
     <meta name="twitter:title" content="Solta - 백준 문제 풀이 통계" />
     <meta name="twitter:description" content="백준 알고리즘 문제 풀이 통계를 한눈에 확인하세요." />
     <meta name="twitter:image" content="/solta-icon.png" />
+    <!-- ChannelTalk -->
+    <script>
+      (function(){var w=window;if(w.ChannelIO){return w.console.error("ChannelIO script included twice.");}var ch=function(){ch.c(arguments);};ch.q=[];ch.c=function(args){ch.q.push(args);};w.ChannelIO=ch;function l(){if(w.ChannelIOInitialized){return;}w.ChannelIOInitialized=true;var s=document.createElement("script");s.type="text/javascript";s.async=true;s.src="https://cdn.channel.io/plugin/ch-plugin-web.js";var x=document.getElementsByTagName("script")[0];if(x.parentNode){x.parentNode.insertBefore(s,x);}}if(document.readyState==="complete"){l();}else{w.addEventListener("DOMContentLoaded",l);w.addEventListener("load",l);}})();
+    </script>
     <!-- Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_ID%"></script>
     <script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,10 @@ import ProblemSearchPage from './pages/ProblemSearchPage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
 import PrivacyPage from './pages/PrivacyPage';
 import BadgePreviewPage from './pages/BadgePreviewPage';
+import { useChannelTalk } from './hooks/useChannelTalk';
 
 function AppContent() {
+	useChannelTalk();
 	const location = useLocation();
 	const hiddenPaths = ['/problems', '/login/success'];
 	const hideHeader = hiddenPaths.includes(location.pathname);

--- a/src/hooks/useChannelTalk.ts
+++ b/src/hooks/useChannelTalk.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { bootChannelTalk, shutdownChannelTalk } from '../utils/channelTalk';
+
+export function useChannelTalk() {
+  const { user, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (user) {
+      bootChannelTalk({
+        memberId: String(user.id),
+        profile: {
+          name: user.name,
+          githubId: user.githubId,
+          bojId: user.bojId,
+        },
+      });
+    } else {
+      bootChannelTalk();
+    }
+
+    return shutdownChannelTalk;
+  }, [user?.id, isLoading]);
+}

--- a/src/utils/channelTalk.ts
+++ b/src/utils/channelTalk.ts
@@ -1,0 +1,28 @@
+declare global {
+  interface Window {
+    ChannelIO?: (method: string, ...args: unknown[]) => void;
+    ChannelIOInitialized?: boolean;
+  }
+}
+
+const PLUGIN_KEY = '2f9158bb-ddb8-40ff-8dcb-0cf2d9ee92c0';
+
+interface ChannelTalkUserProfile {
+  memberId: string;
+  profile: {
+    name: string;
+    githubId: string;
+    bojId: string | null;
+  };
+}
+
+export function bootChannelTalk(user?: ChannelTalkUserProfile) {
+  window.ChannelIO?.('boot', {
+    pluginKey: PLUGIN_KEY,
+    ...user,
+  });
+}
+
+export function shutdownChannelTalk() {
+  window.ChannelIO?.('shutdown');
+}


### PR DESCRIPTION
## Summary
- `index.html`에 ChannelIO 로더 스크립트 추가 (boot 제외, 순수 로더만)
- `src/utils/channelTalk.ts`: `window.ChannelIO` 타입 선언 + `bootChannelTalk` / `shutdownChannelTalk` 유틸
- `src/hooks/useChannelTalk.ts`: 로그인 상태 변화 감지 → 채널톡 회원 정보 자동 연동
- `App.tsx`에 `useChannelTalk()` 훅 추가

## 동작 방식
| 상태 | 채널톡 동작 |
|------|------------|
| 비로그인 | 익명으로 `boot` (위젯 표시) |
| 로그인 | `memberId`, `name`, `githubId`, `bojId` 포함하여 `boot` |
| 로그아웃 | `shutdown` → 익명으로 재`boot` |
| 앱 언마운트 | `shutdown` |

## Test plan
- [ ] 비로그인 상태에서 채널톡 위젯이 표시되는지 확인
- [ ] 로그인 후 채널톡 대시보드에서 회원 정보(이름, githubId, bojId)가 식별되는지 확인
- [ ] 로그아웃 후 익명 세션으로 전환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)