### PR TITLE
feat: 전체 페이지 모바일 반응형 적용

### DIFF
--- a/src/components/ActivityHeatmap/ActivityHeatmap.styled.ts
+++ b/src/components/ActivityHeatmap/ActivityHeatmap.styled.ts
@@ -128,6 +128,8 @@ export const PeriodButton = styled.button<{ $active: boolean }>`
 
 export const SvgWrapper = styled.div`
   position: relative;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 `;
 
 export const Tooltip = styled.div`

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,6 +25,11 @@ const HeaderContent = styled.div`
 	align-items: center;
 	justify-content: center;
 	position: relative;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+		justify-content: space-between;
+		gap: ${({ theme }) => theme.spacing(3)};
+	}
 `;
 
 const LogoSection = styled.div`
@@ -38,6 +43,11 @@ const LogoSection = styled.div`
 
 	&:hover {
 		opacity: 0.8;
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+		position: relative;
+		left: auto;
 	}
 `;
 
@@ -65,12 +75,21 @@ const LogoText = styled.h1`
 	font-weight: bold;
 	color: ${({ theme }) => theme.colors.text};
 	margin: 0;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+		font-size: 1.4rem;
+	}
 `;
 
 const SearchSection = styled.div`
 	max-width: 400px;
 	width: 100%;
 	position: relative;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+		flex: 1;
+		max-width: none;
+	}
 `;
 
 const SearchContainer = styled.div`
@@ -122,6 +141,14 @@ const Dropdown = styled.div`
 	border-radius: ${({ theme }) => theme.borderRadius.md};
 	box-shadow: ${({ theme }) => theme.shadows.lg};
 	z-index: 200;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+		position: fixed;
+		top: 72px;
+		left: ${({ theme }) => theme.spacing(3)};
+		right: ${({ theme }) => theme.spacing(3)};
+		width: auto;
+	}
 `;
 
 const DropdownSection = styled.div`
@@ -225,6 +252,11 @@ const AuthSection = styled.div`
 	display: flex;
 	align-items: center;
 	z-index: 10;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+		position: relative;
+		right: auto;
+	}
 `;
 
 const LoginButton = styled.button`
@@ -243,6 +275,16 @@ const LoginButton = styled.button`
 
 	&:hover {
 		background: ${({ theme }) => theme.colors.border};
+	}
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+		padding: ${({ theme }) => theme.spacing(2)};
+	}
+`;
+
+const LoginButtonText = styled.span`
+	@media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+		display: none;
 	}
 `;
 
@@ -281,6 +323,10 @@ const UserName = styled.span`
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+
+	@media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+		display: none;
+	}
 `;
 
 const UserDropdown = styled.div`
@@ -507,7 +553,7 @@ export function Header() {
 					) : (
 						<LoginButton onClick={handleLogin}>
 							<Github size={16} />
-							GitHub 로그인
+							<LoginButtonText>GitHub 로그인</LoginButtonText>
 						</LoginButton>
 					)}
 				</AuthSection>

--- a/src/components/ProfileStatsCard/ProfileStatsCard.styled.ts
+++ b/src/components/ProfileStatsCard/ProfileStatsCard.styled.ts
@@ -19,13 +19,23 @@ export const StatItem = styled.div`
   @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
     flex: 0 0 50%;
     min-width: 0;
+    padding: ${({ theme }) => theme.spacing(4)};
 
-    &:nth-child(3) {
+    /* 오른쪽 열 (2번째, 4번째 StatItem) */
+    &:nth-child(3),
+    &:nth-child(7) {
+      border-left: 1px solid ${({ theme }) => theme.colors.border};
+    }
+
+    /* 아래 행 (3번째, 4번째 StatItem) */
+    &:nth-child(5),
+    &:nth-child(7) {
       border-top: 1px solid ${({ theme }) => theme.colors.border};
     }
-    &:last-child {
-      border-top: 1px solid ${({ theme }) => theme.colors.border};
-    }
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    padding: ${({ theme }) => theme.spacing(3)};
   }
 `;
 
@@ -49,6 +59,10 @@ export const StatValue = styled.div`
   font-weight: 700;
   color: ${({ theme }) => theme.colors.text};
   line-height: 1.2;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    font-size: 1.05rem;
+  }
 `;
 
 export const StatSubValue = styled.div`

--- a/src/components/RecentActivityFeed/RecentActivityFeed.styled.ts
+++ b/src/components/RecentActivityFeed/RecentActivityFeed.styled.ts
@@ -5,6 +5,10 @@ export const Section = styled.section`
   border-top: 1px solid ${({ theme }) => theme.colors.border};
   border-bottom: 1px solid ${({ theme }) => theme.colors.border};
   padding: ${({ theme }) => theme.spacing(10)} ${({ theme }) => theme.spacing(6)};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    padding: ${({ theme }) => theme.spacing(8)} ${({ theme }) => theme.spacing(4)};
+  }
 `;
 
 export const Inner = styled.div`
@@ -73,7 +77,6 @@ export const StatSummary = styled.p`
   font-size: 0.82rem;
   color: ${({ theme }) => theme.colors.textMuted};
   margin: 0;
-  white-space: nowrap;
 `;
 
 export const StatNum = styled.span`
@@ -102,6 +105,7 @@ export const Row = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius.sm};
   cursor: pointer;
   transition: background 0.15s ease;
+  overflow: hidden;
 
   &:hover {
     background: ${({ theme }) => theme.colors.bgTertiary};
@@ -124,12 +128,6 @@ export const RowBody = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: ${({ theme }) => theme.spacing(3)};
-
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 2px;
-  }
 `;
 
 export const RowLeft = styled.div`
@@ -138,6 +136,7 @@ export const RowLeft = styled.div`
   gap: ${({ theme }) => theme.spacing(2)};
   min-width: 0;
   flex: 1;
+  overflow: hidden;
 `;
 
 export const Username = styled.span`
@@ -158,6 +157,7 @@ export const ProblemText = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  flex: 1;
 `;
 
 export const ProblemName = styled.span`

--- a/src/components/SolveTrendsChart/SolveTrendsChart.styled.ts
+++ b/src/components/SolveTrendsChart/SolveTrendsChart.styled.ts
@@ -6,6 +6,10 @@ export const Container = styled.div`
   padding: ${({ theme }) => theme.spacing(6)};
   box-shadow: ${({ theme }) => theme.shadows.md};
   border: 1px solid ${({ theme }) => theme.colors.border};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    padding: ${({ theme }) => theme.spacing(4)};
+  }
 `;
 
 export const Header = styled.div`

--- a/src/components/SolvedItem/SolvedItem.styled.ts
+++ b/src/components/SolvedItem/SolvedItem.styled.ts
@@ -62,6 +62,11 @@ export const ProblemMeta = styled.div`
   align-items: center;
   gap: ${({ theme }) => theme.spacing(3)};
   flex-wrap: wrap;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    flex-wrap: nowrap;
+    overflow: hidden;
+  }
 `;
 
 export const TierText = styled.span<{ color: string }>`
@@ -76,6 +81,7 @@ export const MetaItem = styled.div`
   gap: 4px;
   font-size: 0.75rem;
   color: ${({ theme }) => theme.colors.textSecondary};
+  white-space: nowrap;
 
   svg {
     flex-shrink: 0;
@@ -85,6 +91,22 @@ export const MetaItem = styled.div`
 export const DateText = styled.span`
   font-size: 0.75rem;
   color: ${({ theme }) => theme.colors.textSecondary};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    display: none;
+  }
+`;
+
+export const DateTextMobile = styled.span`
+  display: none;
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.textMuted};
+  flex-shrink: 0;
+  white-space: nowrap;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    display: block;
+  }
 `;
 
 export const XpBadge = styled.span`
@@ -121,5 +143,9 @@ export const ExternalLinkIcon = styled.div`
 
   ${Container}:hover & {
     opacity: 1;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    display: none;
   }
 `;

--- a/src/components/SolvedItem/SolvedItem.tsx
+++ b/src/components/SolvedItem/SolvedItem.tsx
@@ -90,6 +90,10 @@ export function SolvedItem({ solved, showSolveType = false, showDate = false, on
         <Styled.XpBadge>+{solved.earnedXp} XP</Styled.XpBadge>
       )}
 
+      {showDate && solved.createdAt && (
+        <Styled.DateTextMobile>{formatDate(solved.createdAt)}</Styled.DateTextMobile>
+      )}
+
       {showSolveType && (
         <Styled.SolveTypeBadge solveType={solved.solveType}>
           {solved.solveType === "SELF" ? "스스로" : "참고"}

--- a/src/components/TierStatsChart/TierStatsChart.styled.ts
+++ b/src/components/TierStatsChart/TierStatsChart.styled.ts
@@ -75,6 +75,10 @@ export const EmptyState = styled.div`
 export const ChartWrapper = styled.div`
   width: 100%;
   height: 400px;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    height: 280px;
+  }
 `;
 
 export const InsightBox = styled.div`

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,6 +14,10 @@ const Hero = styled.section`
   padding: ${({ theme }) => theme.spacing(16)} ${({ theme }) => theme.spacing(6)} ${({ theme }) => theme.spacing(12)};
   max-width: 720px;
   margin: 0 auto;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    padding: ${({ theme }) => theme.spacing(10)} ${({ theme }) => theme.spacing(4)} ${({ theme }) => theme.spacing(8)};
+  }
 `;
 
 const LogoRow = styled.div`
@@ -49,6 +53,10 @@ const Title = styled.h1`
   span {
     color: ${({ theme }) => theme.colors.primary};
   }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    font-size: 2rem;
+  }
 `;
 
 const Subtitle = styled.p`
@@ -56,12 +64,22 @@ const Subtitle = styled.p`
   color: ${({ theme }) => theme.colors.textSecondary};
   margin: 0 0 ${({ theme }) => theme.spacing(8)} 0;
   line-height: 1.7;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    font-size: 1rem;
+  }
 `;
 
 const CTARow = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.spacing(3)};
   justify-content: center;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 0 ${({ theme }) => theme.spacing(2)};
+  }
 `;
 
 const CTAButton = styled.button<{ $primary?: boolean }>`

--- a/src/pages/ProblemSearchPage.styled.ts
+++ b/src/pages/ProblemSearchPage.styled.ts
@@ -31,6 +31,10 @@ export const ContentArea = styled.div`
   flex: 1;
   display: flex;
   min-height: 0;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    overflow: hidden;
+  }
 `;
 
 // Left: Search + List
@@ -153,11 +157,59 @@ export const EmptyState = styled.div`
 `;
 
 // Right: Detail panel
-export const DetailSection = styled.div`
+export const DetailSection = styled.div<{ $hasSelection?: boolean }>`
   width: 420px;
   flex-shrink: 0;
   background: ${({ theme }) => theme.colors.bgSecondary};
   overflow-y: auto;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    z-index: 200;
+    display: ${({ $hasSelection }) => ($hasSelection ? 'flex' : 'none')};
+    flex-direction: column;
+    overflow-y: auto;
+  }
+`;
+
+export const MobileDetailHeader = styled.div`
+  display: none;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    display: flex;
+    align-items: center;
+    padding: ${({ theme }) => theme.spacing(3)} ${({ theme }) => theme.spacing(4)};
+    border-bottom: 1px solid ${({ theme }) => theme.colors.border};
+    background: ${({ theme }) => theme.colors.bgSecondary};
+    flex-shrink: 0;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+`;
+
+export const MobileBackButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing(2)};
+  background: none;
+  border: none;
+  color: ${({ theme }) => theme.colors.textSecondary};
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: ${({ theme }) => theme.spacing(1)};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.bgTertiary};
+    color: ${({ theme }) => theme.colors.text};
+  }
 `;
 
 export const DetailPlaceholder = styled.div`

--- a/src/pages/ProblemSearchPage.tsx
+++ b/src/pages/ProblemSearchPage.tsx
@@ -171,7 +171,13 @@ export default function ProblemSearchPage() {
         </Styled.ListSection>
 
         {/* Right: Detail Panel */}
-        <Styled.DetailSection>
+        <Styled.DetailSection $hasSelection={!!selectedProblem}>
+          <Styled.MobileDetailHeader>
+            <Styled.MobileBackButton onClick={() => setSelectedProblem(null)}>
+              <ArrowLeft size={18} />
+              목록으로
+            </Styled.MobileBackButton>
+          </Styled.MobileDetailHeader>
           {selectedProblem ? (
             isDetailLoading ? (
               <Styled.DetailLoading>불러오는 중...</Styled.DetailLoading>

--- a/src/pages/ProfilePage.styled.ts
+++ b/src/pages/ProfilePage.styled.ts
@@ -6,6 +6,14 @@ export const ProfileContainer = styled.div`
   width: 100%;
   min-height: 100vh;
   background: ${({ theme }) => theme.colors.bg};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    padding: ${({ theme }) => theme.spacing(4)};
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    padding: ${({ theme }) => theme.spacing(3)};
+  }
 `;
 
 export const UserSection = styled.div`
@@ -20,6 +28,10 @@ export const UserSection = styled.div`
 
 export const UserSectionTop = styled.div`
   padding: ${({ theme }) => theme.spacing(6)};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    padding: ${({ theme }) => theme.spacing(4)};
+  }
 `;
 
 export const UserCardDivider = styled.div`
@@ -31,6 +43,10 @@ export const UserInfo = styled.div`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.spacing(4)};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    align-items: flex-start;
+  }
 `;
 
 export const UserIconWrapper = styled.div`
@@ -77,6 +93,7 @@ export const UserHeader = styled.div`
   align-items: center;
   gap: ${({ theme }) => theme.spacing(2)};
   margin-bottom: ${({ theme }) => theme.spacing(2)};
+  flex-wrap: wrap;
 `;
 
 export const UserId = styled.h1`
@@ -84,6 +101,10 @@ export const UserId = styled.h1`
   color: ${({ theme }) => theme.colors.text};
   margin: 0;
   font-weight: 700;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    font-size: 1.4rem;
+  }
 `;
 
 export const SolvedAcLink = styled.a`
@@ -360,6 +381,10 @@ export const FullWidthSection = styled.div`
   padding: ${({ theme }) => theme.spacing(6)};
   box-shadow: ${({ theme }) => theme.shadows.md};
   border: 1px solid ${({ theme }) => theme.colors.border};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    padding: ${({ theme }) => theme.spacing(4)};
+  }
 `;
 
 export const TwoColumnGrid = styled.div`
@@ -528,6 +553,10 @@ export const DrawerPanel = styled.div<{ $open: boolean }>`
   transition: transform 0.25s ease;
   display: flex;
   flex-direction: column;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
+    width: 100%;
+  }
 `;
 
 export const DrawerHeader = styled.div`


### PR DESCRIPTION
## Summary
전체 페이지에 모바일 반응형 스타일 적용

## 왜 필요한가
모바일 환경에서 레이아웃이 깨지거나 텍스트가 화면 밖으로 넘어가는 문제가 있었음.
헤더 검색창, 프로필 드로어, 문제 검색 상세 패널 등 주요 UI가 모바일에서 사용하기 어려운 상태였음.

## 동작 방식
- `≤768px`: 헤더가 flex row로 전환, 프로필 DrawerPanel 전체 폭, ProblemSearch 상세 패널 오버레이
- `≤480px`: 타이틀 폰트 축소, CTA 버튼 세로 스택, ProfileStatsCard 2×2 그리드

## 주요 변경 사항
- `Header.tsx` — absolute 레이아웃 → 모바일 flex row 전환, 검색 드롭다운 `position: fixed`로 전체 폭 확장
- `HomePage.tsx` — 타이틀/서브타이틀 폰트 축소, CTA 버튼 모바일 세로 스택
- `ProfilePage.styled.ts` — 패딩 축소, UserId 폰트 축소, UserHeader flex-wrap, DrawerPanel 모바일 전체 폭
- `ProfileStatsCard.styled.ts` — 2×2 그리드 경계선 nth-child 수정 (세로·가로선 모두), StatValue 폰트 축소
- `ProblemSearchPage.styled.ts` / `.tsx` — 모바일 상세 패널 전체화면 오버레이 + "목록으로" 닫기 버튼 추가
- `ActivityHeatmap.styled.ts` — SvgWrapper 가로 스크롤 처리
- `RecentActivityFeed.styled.ts` — StatSummary nowrap 제거, RowLeft/Row overflow: hidden
- `SolvedItem.styled.ts` / `.tsx` — ProblemMeta nowrap, MetaItem white-space nowrap, 날짜 모바일 별도 표시, ExternalLinkIcon 모바일 숨김
- `SolveTrendsChart.styled.ts` / `TierStatsChart.styled.ts` — 모바일 패딩·차트 높이 축소

## Test plan
- [x] 모바일(375px)에서 헤더 검색창 및 드롭다운 전체 폭 확인
- [x] ProfilePage DrawerPanel 전체 폭으로 열리는지 확인
- [x] ProblemSearchPage 문제 선택 시 오버레이 표시 및 "목록으로" 닫기 확인
- [x] SolvedItem 카드 높이가 컨텐츠에 관계없이 일정한지 확인
- [x] ActivityHeatmap 가로 스크롤 확인
- [x] ProfileStatsCard 2×2 그리드 경계선 4방향 모두 표시 확인